### PR TITLE
CREATE-887: FabricJS doesn't set the cursor on mouse down event

### DIFF
--- a/src/mixins/canvas_events.mixin.js
+++ b/src/mixins/canvas_events.mixin.js
@@ -739,6 +739,7 @@
           }
         }
       }
+      this._setCursorFromEvent(e, target);
       this._handleEvent(e, 'down');
       // we must renderAll so that we update the visuals
       (shouldRender || shouldGroup) && this.requestRenderAll();


### PR DESCRIPTION
Fabric sets the cursor for controls on mouse up events but doesn't do so for mouse down ones.

This is currently needed for the timeline shape, which has grab and grabbing cursors on the hover and mouse up events.


- Fire setCursorFromEvent from within __onMouseDown