### PR TITLE
Backport filter option into toCanvasElement

### DIFF
--- a/src/mixins/canvas_dataurl_exporter.mixin.js
+++ b/src/mixins/canvas_dataurl_exporter.mixin.js
@@ -11,6 +11,7 @@
      * @param {Number} [options.top] Cropping top offset. Introduced in v1.2.14
      * @param {Number} [options.width] Cropping width. Introduced in v1.2.14
      * @param {Number} [options.height] Cropping height. Introduced in v1.2.14
+     * @param {(object: fabric.Object) => boolean} [options.filter] Function to filter objects.
      * @param {Boolean} [options.enableRetinaScaling] Enable retina scaling for clone image. Introduce in 2.0.0
      * @return {String} Returns a data: URL containing a representation of the object in the format specified by options.format
      * @see {@link http://jsfiddle.net/fabricjs/NfZVb/|jsFiddle demo}
@@ -50,29 +51,33 @@
      * This is an intermediary step used to get to a dataUrl but also it is useful to
      * create quick image copies of a canvas without passing for the dataUrl string
      * @param {Number} [multiplier] a zoom factor.
-     * @param {Object} [cropping] Cropping informations
-     * @param {Number} [cropping.left] Cropping left offset.
-     * @param {Number} [cropping.top] Cropping top offset.
-     * @param {Number} [cropping.width] Cropping width.
-     * @param {Number} [cropping.height] Cropping height.
+     * @param {Object} [options] Cropping informations
+     * @param {Number} [options.left] Cropping left offset.
+     * @param {Number} [options.top] Cropping top offset.
+     * @param {Number} [options.width] Cropping width.
+     * @param {Number} [options.height] Cropping height.
+     * @param {(object: fabric.Object) => boolean} [options.filter] Function to filter objects.
      */
-    toCanvasElement: function(multiplier, cropping) {
+    toCanvasElement: function(multiplier, options) {
       multiplier = multiplier || 1;
-      cropping = cropping || { };
-      var scaledWidth = (cropping.width || this.width) * multiplier,
-          scaledHeight = (cropping.height || this.height) * multiplier,
+      options = options || { };
+      var scaledWidth = (options.width || this.width) * multiplier,
+          scaledHeight = (options.height || this.height) * multiplier,
           zoom = this.getZoom(),
           originalWidth = this.width,
           originalHeight = this.height,
           newZoom = zoom * multiplier,
           vp = this.viewportTransform,
-          translateX = (vp[4] - (cropping.left || 0)) * multiplier,
-          translateY = (vp[5] - (cropping.top || 0)) * multiplier,
+          translateX = (vp[4] - (options.left || 0)) * multiplier,
+          translateY = (vp[5] - (options.top || 0)) * multiplier,
           originalInteractive = this.interactive,
           newVp = [newZoom, 0, 0, newZoom, translateX, translateY],
           originalRetina = this.enableRetinaScaling,
           canvasEl = fabric.util.createCanvasElement(),
-          originalContextTop = this.contextTop;
+          originalContextTop = this.contextTop,
+          objectsToRender = options?.filter
+            ? this._chooseObjectsToRender().filter((obj) => options.filter(obj))
+            : this._chooseObjectsToRender();
       canvasEl.width = scaledWidth;
       canvasEl.height = scaledHeight;
       this.contextTop = null;
@@ -82,7 +87,7 @@
       this.width = scaledWidth;
       this.height = scaledHeight;
       this.calcViewportBoundaries();
-      this.renderCanvas(canvasEl.getContext('2d'), this._chooseObjectsToRender());
+      this.renderCanvas(canvasEl.getContext('2d'), objectsToRender);
       this.viewportTransform = vp;
       this.width = originalWidth;
       this.height = originalHeight;


### PR DESCRIPTION
Newer fabric lets you supply a `filter` to `toDataUrl` and `toCanvasElement` which allows exporting a subset of objects. I've backported this change to our version so we can support exporting individual Frames as PNGs.

There's no typing in this, so do we just `// @ts-ignore` in the aha-app when supplying the filter?

Required by PR: https://github.com/aha-app/aha-app/pull/41322